### PR TITLE
add computer player move message

### DIFF
--- a/game.py
+++ b/game.py
@@ -10,14 +10,13 @@ class Game:
         self.validator = validator
 
     def play_round(self):
-        self.console.print_string(str(self.board))
-
         self.console.print_board(self.board.get_board())
         current_player = self.players.get_current_player()
         name = current_player.get_name()
         current_mark = current_player.get_mark()
 
         if name == "Bot":
+            self.console.print_string("Watch in awe as Player Bot makes a really impressive move!")
             move = current_player.make_move(self.board.get_board())
         else:
             move_prompt = f'\nHi Player {name}! Enter a value please: '

--- a/test_game.py
+++ b/test_game.py
@@ -157,16 +157,26 @@ class TestComputerOpponentGame(unittest.TestCase):
         self.game = Game(self.board, self.players, self.console, self.validator)
 
     def test_play_round(self):
-        current_player = self.players.get_current_player.return_value\
-            = MagicMock(name='Bot', mark='x')
+        with self.subTest("should tell the user the computer is making its move"):
+            game = Game(self.board, self.players, self.console, self.validator)
+            current_player = self.players.get_current_player.return_value \
+                = MagicMock(name='Bot', mark='x')
+            current_player.get_name.return_value = 'Bot'
+
+            game.play_round()
+
+            message = "Watch in awe as Player Bot makes a really impressive move!"
+            self.console.print_string.assert_called_once_with(message)
 
         with self.subTest("should get computer's move to update the board"):
+            game = Game(self.board, self.players, self.console, self.validator)
+            current_player = self.players.get_current_player.return_value \
+                = MagicMock(name='Bot', mark='x')
             current_player.get_name.return_value = 'Bot'
             self.game.board.get_board = MagicMock()
-            self.game.current_player = MagicMock()
             current_player.make_move.return_value = 1
 
-            self.game.play_round()
+            game.play_round()
 
             current_player.make_move.assert_called_once_with(self.game.board.get_board())
 


### PR DESCRIPTION
## Changes made

1. add console message that computer is making its move

## Acceptance criteria

1. For the human player’s turn, print the board and a message stating that it’s the human player’s turn
2. If the human player attempts to mark an invalid cell, then show a corresponding message and allow the player to retry their turn
3. For the computer player’s turn, print the board and a message stating that the computer is processing its move
4. Wins or draws should be identified and the application should gracefully exit afterwards

## Comments
The test I wrote for the "computer move message" was affecting the "get computer move" test so I had to refactor both tests to make sure they weren't affecting each other. This is something I am going to pay closer attention to going forward. it seems to be a common issue with subtests from what I'm reading?

[trello ticket](https://trello.com/c/cVrAyObq)